### PR TITLE
Update to use Sentient’s concrete syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ another.
 
 The heart of the library is a [Sentient program which describes ISBNs in terms
 of
-invariants](https://github.com/mudge/sentient-isbn/blob/master/lib/isbn.js#L7-L240)
+invariants](https://github.com/mudge/sentient-isbn/blob/master/lib/isbn.snt)
 such as:
 
 * All digits must be between 0 and 9 inclusive except an ISBN-10's check digit

--- a/lib/isbn.js
+++ b/lib/isbn.js
@@ -1,249 +1,18 @@
 'use strict';
 
 var Sentient = require('sentient-lang'),
+    fs = require('fs'),
     program,
     ISBN;
 
-/* A Sentient program to encode ISBN-10s, ISBN-13s, their check digits and how they relate. */
-program = Sentient.compile({
-    instructions: [
-
-        /* Declare all parts of the ISBN including check digits. */
-        {type: 'integer', symbol: 'ten0', width: 5},
-        {type: 'integer', symbol: 'ten1', width: 5},
-        {type: 'integer', symbol: 'ten2', width: 5},
-        {type: 'integer', symbol: 'ten3', width: 5},
-        {type: 'integer', symbol: 'ten4', width: 5},
-        {type: 'integer', symbol: 'ten5', width: 5},
-        {type: 'integer', symbol: 'ten6', width: 5},
-        {type: 'integer', symbol: 'ten7', width: 5},
-        {type: 'integer', symbol: 'ten8', width: 5},
-        {type: 'integer', symbol: 'tenCheckDigit', width: 5},
-        {type: 'integer', symbol: 'thirteenCheckDigit', width: 5},
-
-        /* State that all digits must be between 0 and 9 inclusive aside from ISBN-10 check digits
-         * which can include 10.
-         */
-        {type: 'push', symbol: 'ten0'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten0'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten1'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten1'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten2'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten2'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten3'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten3'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten4'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten4'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten5'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten5'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten6'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten6'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten7'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten7'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten8'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'ten8'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'tenCheckDigit'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'tenCheckDigit'},
-        {type: 'constant', value: 10},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'thirteenCheckDigit'},
-        {type: 'constant', value: 0},
-        {type: 'greaterequal'},
-        {type: 'invariant'},
-        {type: 'push', symbol: 'thirteenCheckDigit'},
-        {type: 'constant', value: 9},
-        {type: 'lessequal'},
-        {type: 'invariant'},
-
-        /* Collect all digits in an ISBN-10. */
-        {type: 'push', symbol: 'ten0'},
-        {type: 'push', symbol: 'ten1'},
-        {type: 'push', symbol: 'ten2'},
-        {type: 'push', symbol: 'ten3'},
-        {type: 'push', symbol: 'ten4'},
-        {type: 'push', symbol: 'ten5'},
-        {type: 'push', symbol: 'ten6'},
-        {type: 'push', symbol: 'ten7'},
-        {type: 'push', symbol: 'ten8'},
-        {type: 'push', symbol: 'tenCheckDigit'},
-        {type: 'collect', width: 10},
-        {type: 'pop', symbol: 'tenDigit'},
-
-        /* Declare how to verify ISBN-10s (including their check digits).
-         *
-         * 1. Add together each digit, multiplying by their index;
-         * 2. Take the result modulo 11;
-         * 3. State that the result must be 0.
-         */
-        {type: 'push', symbol: 'ten0'},
-        {type: 'push', symbol: 'ten1'},
-        {type: 'constant', value: 2},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten2'},
-        {type: 'constant', value: 3},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten3'},
-        {type: 'constant', value: 4},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten4'},
-        {type: 'constant', value: 5},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten5'},
-        {type: 'constant', value: 6},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten6'},
-        {type: 'constant', value: 7},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten7'},
-        {type: 'constant', value: 8},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten8'},
-        {type: 'constant', value: 9},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'push', symbol: 'tenCheckDigit'},
-        {type: 'constant', value: 10},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'constant', value: 11},
-        {type: 'modulo'},
-        {type: 'constant', value: 0},
-        {type: 'equal'},
-        {type: 'invariant'},
-
-        /* Declare how to verify ISBN-13s (including their check digit).
-         *
-         * 1. Add all even-numbered digits;
-         * 2. Add all odd-numbered digits and multiply by 3;
-         * 3. Add both sums together modulo 10;
-         * 4. State that the result must equal 0
-         */
-        {type: 'constant', value: 9},
-        {type: 'constant', value: 8},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten1'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten3'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten5'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten7'},
-        {type: 'add'},
-        {type: 'push', symbol: 'thirteenCheckDigit'},
-        {type: 'add'},
-        {type: 'constant', value: 7},
-        {type: 'push', symbol: 'ten0'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten2'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten4'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten6'},
-        {type: 'add'},
-        {type: 'push', symbol: 'ten8'},
-        {type: 'add'},
-        {type: 'constant', value: 3},
-        {type: 'multiply'},
-        {type: 'add'},
-        {type: 'constant', value: 10},
-        {type: 'modulo'},
-        {type: 'constant', value: 0},
-        {type: 'equal'},
-        {type: 'invariant'},
-
-        /* Collect together all the digits in an ISBN-13. */
-        {type: 'constant', value: 9},
-        {type: 'constant', value: 7},
-        {type: 'constant', value: 8},
-        {type: 'push', symbol: 'ten0'},
-        {type: 'push', symbol: 'ten1'},
-        {type: 'push', symbol: 'ten2'},
-        {type: 'push', symbol: 'ten3'},
-        {type: 'push', symbol: 'ten4'},
-        {type: 'push', symbol: 'ten5'},
-        {type: 'push', symbol: 'ten6'},
-        {type: 'push', symbol: 'ten7'},
-        {type: 'push', symbol: 'ten8'},
-        {type: 'push', symbol: 'thirteenCheckDigit'},
-        {type: 'collect', width: 13},
-        {type: 'pop', symbol: 'thirteenDigit'},
-
-        /* Expose thirteenDigit and tenDigit in the result. */
-        {type: 'variable', symbol: 'thirteenDigit'},
-        {type: 'variable', symbol: 'tenDigit'}
-    ]
-});
+program = fs.readFileSync(__dirname + "/isbn.snt", "utf8");
+program = Sentient.compile(program);
 
 ISBN = function (options) {
     var isbn10, isbn13, i, digit;
 
-    this.tenDigit = new Array(10);
-    this.thirteenDigit = new Array(13);
+    this.ten_digit = new Array(10);
+    this.thirteen_digit = new Array(13);
 
     if (options.hasOwnProperty('isbn10')) {
         isbn10 = options.isbn10.replace(/-/g, '');
@@ -252,9 +21,9 @@ ISBN = function (options) {
             digit = isbn10.charAt(i);
 
             if (digit === 'X') {
-                this.tenDigit[i] = 10;
+                this.ten_digit[i] = 10;
             } else if (digit !== '?') {
-                this.tenDigit[i] = parseInt(digit, 10);
+                this.ten_digit[i] = parseInt(digit, 10);
             }
         }
     }
@@ -266,7 +35,7 @@ ISBN = function (options) {
             digit = isbn13.charAt(i);
 
             if (digit !== '?') {
-                this.thirteenDigit[i] = parseInt(digit, 10);
+                this.thirteen_digit[i] = parseInt(digit, 10);
             }
         }
     }
@@ -277,12 +46,12 @@ ISBN.prototype.results = function () {
         return this.result;
     }
 
-    this.result = Sentient.run(program, {tenDigit: this.tenDigit, thirteenDigit: this.thirteenDigit});
+    this.result = Sentient.run(program, {ten_digit: this.ten_digit, thirteen_digit: this.thirteen_digit});
     return this.result;
 };
 
 ISBN.prototype.isbn10 = function () {
-    var isbn10 = this.results().tenDigit;
+    var isbn10 = this.results().ten_digit;
 
     if (isbn10[9] === 10) {
         return isbn10.slice(0, 9).join('') + 'X';
@@ -292,7 +61,7 @@ ISBN.prototype.isbn10 = function () {
 };
 
 ISBN.prototype.isbn13 = function () {
-    var isbn13 = this.results().thirteenDigit;
+    var isbn13 = this.results().thirteen_digit;
 
     return isbn13.join('');
 };

--- a/lib/isbn.snt
+++ b/lib/isbn.snt
@@ -1,0 +1,100 @@
+# A Sentient program to encode ISBN-10s, ISBN-13s, their check
+# digits and how they relate.
+
+
+# Declare all parts of the ISBN including check digits.
+
+int5 ten0, ten1, ten2, ten3, ten4, ten5, ten6, ten7, ten8;
+int5 ten_check_digit, thirteen_check_digit;
+
+# State that all digits must be between 0 and 9 inclusive aside
+# from ISBN-10 check digits which can include 10.
+
+invariant ten0 >= 0, ten0 <= 9;
+invariant ten1 >= 0, ten1 <= 9;
+invariant ten2 >= 0, ten2 <= 9;
+invariant ten3 >= 0, ten3 <= 9;
+invariant ten4 >= 0, ten4 <= 9;
+invariant ten5 >= 0, ten5 <= 9;
+invariant ten6 >= 0, ten6 <= 9;
+invariant ten7 >= 0, ten7 <= 9;
+invariant ten8 >= 0, ten8 <= 9;
+invariant ten_check_digit >= 0, ten_check_digit <= 10;
+invariant thirteen_check_digit >= 0, thirteen_check_digit <= 9;
+
+# Collect all digits in an ISBN-10.
+
+ten_digit = [
+  ten0,
+  ten1,
+  ten2,
+  ten3,
+  ten4,
+  ten5,
+  ten6,
+  ten7,
+  ten8,
+  ten_check_digit
+];
+
+# Declare how to verify ISBN-10s (including their check digits).
+#
+# 1. Add together each digit, multiplying by their index;
+# 2. Take the result modulo 11;
+# 3. State that the result must be 0.
+
+ten_total  = ten0;
+ten_total += ten1 * 2;
+ten_total += ten2 * 3;
+ten_total += ten3 * 4;
+ten_total += ten4 * 5;
+ten_total += ten5 * 6;
+ten_total += ten6 * 7;
+ten_total += ten7 * 8;
+ten_total += ten8 * 9;
+ten_total += ten_check_digit * 10;
+
+invariant ten_total % 11 == 0;
+
+# Declare how to verify ISBN-13s (including their check digit).
+#
+# 1. Add all even-numbered digits;
+# 2. Add all odd-numbered digits and multiply by 3;
+# 3. Add both sums together modulo 10;
+# 4. State that the result must equal 0
+
+even_digits  = 9;
+even_digits += 8;
+even_digits += ten1;
+even_digits += ten3;
+even_digits += ten5;
+even_digits += ten7;
+even_digits += thirteen_check_digit;
+
+odd_digits  = 7;
+odd_digits += ten0;
+odd_digits += ten2;
+odd_digits += ten4;
+odd_digits += ten6;
+odd_digits += ten8;
+
+invariant (even_digits + odd_digits * 3) % 10 == 0;
+
+# Collect together all the digits in an ISBN-13.
+
+thirteen_digit = [9, 7, 8,
+  ten0,
+  ten1,
+  ten2,
+  ten3,
+  ten4,
+  ten5,
+  ten6,
+  ten7,
+  ten8,
+  thirteen_check_digit
+];
+
+# Expose thirteen_digit and ten_digit in the result.
+
+vary thirteen_digit, ten_digit;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mudge/sentient-isbn#readme",
   "dependencies": {
-    "sentient-lang": "0.0.0-alpha.1"
+    "sentient-lang": "0.0.0-alpha.3"
   },
   "devDependencies": {
     "mocha": "^2.4.5"


### PR DESCRIPTION
I've tried to preserve as much of the original program structure as possible.

Sentient only supports lower case variables at the moment.

I've also been working on a command line tool that lets you do:

```
$ npm install sentient-lang -g
$ sentient lib/isbn.snt --set '{ ten_digit: [0, 8, 0, undefined, 4, 2, 9, 5, 7, 10] }'
```

Returning:

``` javascript
{ thirteen_digit: [ 9, 7, 8, 0, 8, 0, 4, 4, 2, 9, 5, 7, 3 ],
  ten_digit: [ 0, 8, 0, 4, 4, 2, 9, 5, 7, 10 ] }
```
